### PR TITLE
Handle CAPTCHA_NEEDED error

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -30,6 +30,10 @@ end
 def extract_score(res)
   return nil unless res.success?
   data = JSON.parse(res.body)
+  unless data['ruleGroups']
+    logger.warn "result has no ruleGroups: #{data.inspect}"
+    return nil
+  end
   data['ruleGroups']['SPEED']['score']
 end
 
@@ -101,6 +105,8 @@ task :post do
   mackerel_service = ENV['MACKEREL_SERVICE'] or abort "MACKEREL_SERVICE required"
   urls             = ENV['URLS'].split(/\s/)
 
-  scores = fetch_psi_scores(urls)
-  post_scores_to_mackerel(mackerel_service: mackerel_service, api_key: api_key, scores: scores)
+  scores = fetch_psi_scores(urls).select{|score| score[1] }
+  if scores.length > 0
+    post_scores_to_mackerel(mackerel_service: mackerel_service, api_key: api_key, scores: scores)
+  end
 end


### PR DESCRIPTION
- The API sometime returns 200 OK, but it lacks speed metrics.
  - This is because we don't specify api key.
  - https://developers.google.com/speed/docs/insights/faq
- This pull request handles that error, and skip posting when the result with scores are empty.

```
I, [2018-05-16T18:03:26.602487 #40376]  INFO -- : rake run
I, [2018-05-16T18:03:26.602558 #40376]  INFO -- : Fetch scores
I, [2018-05-16T18:03:26.649530 #40376]  INFO -- : Fetch score of https://example.com/
I, [2018-05-16T18:03:26.801026 #40376]  INFO -- : Done: https://example.com/
W, [2018-05-16T18:03:26.801286 #40376]  WARN -- : result has no ruleGroups: {"captchaResult"=>"CAPTCHA_NEEDED", "kind"=>"pagespeedonline#result"}
```