### PR TITLE
 Set API key via `GOOGLE_APIKEY` environment variable

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -38,14 +38,18 @@ def as_metric_name(str)
 end
 
 # => [url: String, score: Integer]
-def fetch_psi_scores(urls)
+def fetch_psi_scores(urls, api_key)
   logger.info "Fetch scores"
   client = Faraday.new(url: 'https://www.googleapis.com')
   results = Parallel.map(urls, in_threads: 4) {|url|
     logger.info "Fetch score of #{url}"
+    params = {
+      url: url
+    }
+    params[:key] = api_key if api_key
     [
       url,
-      client.get('/pagespeedonline/v2/runPagespeed', url: url).tap { logger.info "Done: #{url}" }
+      client.get('/pagespeedonline/v2/runPagespeed', params).tap { logger.info "Done: #{url}" }
     ]
   }
   results.map {|(url, res)| [url, extract_score(res)] }
@@ -61,7 +65,7 @@ def post_scores_to_mackerel(mackerel_service: , api_key: , scores: )
       unit: 'float',
       metrics: (scores.map {|(url, _)| [url, as_metric_name(url)] }.map {|(url, safe_url)|
         {
-          name: "custom.pagespeed.#{safe_url}", 
+          name: "custom.pagespeed.#{safe_url}",
           displayName: url,
           isStacked: false,
         }
@@ -99,8 +103,9 @@ task :post do
 
   api_key          = ENV['MACKEREL_APIKEY'] or abort "MACKEREL_APIKEY required"
   mackerel_service = ENV['MACKEREL_SERVICE'] or abort "MACKEREL_SERVICE required"
+  google_api_key   = ENV['GOOGLE_APIKEY'] # optional
   urls             = ENV['URLS'].split(/\s/)
 
-  scores = fetch_psi_scores(urls)
+  scores = fetch_psi_scores(urls, google_api_key)
   post_scores_to_mackerel(mackerel_service: mackerel_service, api_key: api_key, scores: scores)
 end

--- a/app.json
+++ b/app.json
@@ -10,6 +10,10 @@
       "description": "A service name of the metrics",
       "required": true
     },
+    "GOOGLE_APIKEY": {
+      "description": "(optional) API key of Google. You must activate PageSpeed Insights API.",
+      "required": false
+    },
     "INTERVAL_SECS": {
       "description": "Run interval in seconds (The value must be valid as a integer)",
       "value": "60"


### PR DESCRIPTION
My use-case needs API key because I want to measure more than 20 URLs.

> Why am I seeing a captcha?
PageSpeed Insights may occasionally show a captcha to confirm you are not a bot. If you are encountering a captcha when using the API, it may be due to the fact that you are using a shared API key. You can acquire an individual API Key by following these instructions.
https://developers.google.com/speed/docs/insights/faq