### PR TITLE
PSIのAPIがv2からv5になっていたのでバージョンアップした

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -79,7 +79,7 @@ def post_scores_to_mackerel(mackerel_service: , api_key: , scores: )
   mackerel_client.post_service_metrics(mackerel_service, scores.map {|(url, score)|
     {
       name: "custom.pagespeed.#{as_metric_name(url)}",
-      value: score,
+      value: score * 100,
       time: now.to_i,
     }
   })

--- a/Rakefile
+++ b/Rakefile
@@ -107,7 +107,7 @@ task :kick do
   logger.info 'kicking PSI'
   google_api_key   = ENV['GOOGLE_APIKEY'] # optional
   urls             = ENV['URLS'].split(/\s/)
-  scores = fetch_psi_scores(urls, google_api_key).select(|(url, score)| score)
+  scores = fetch_psi_scores(urls, google_api_key).select {|(url, score)| score}
   p scores
 end
 
@@ -119,7 +119,7 @@ task :post do
   google_api_key   = ENV['GOOGLE_APIKEY'] # optional
   urls             = ENV['URLS'].split(/\s/)
 
-  scores = fetch_psi_scores(urls, google_api_key).select(|(url, score)| score)
+  scores = fetch_psi_scores(urls, google_api_key).select {|(url, score)| score}
   if scores.length > 0
     post_scores_to_mackerel(mackerel_service: mackerel_service, api_key: api_key, scores: scores)
   end

--- a/Rakefile
+++ b/Rakefile
@@ -107,7 +107,7 @@ task :kick do
   logger.info 'kicking PSI'
   google_api_key   = ENV['GOOGLE_APIKEY'] # optional
   urls             = ENV['URLS'].split(/\s/)
-  scores = fetch_psi_scores(urls, google_api_key)
+  scores = fetch_psi_scores(urls, google_api_key).select(|(url, score)| score)
   p scores
 end
 
@@ -119,7 +119,7 @@ task :post do
   google_api_key   = ENV['GOOGLE_APIKEY'] # optional
   urls             = ENV['URLS'].split(/\s/)
 
-  scores = fetch_psi_scores(urls, google_api_key)
+  scores = fetch_psi_scores(urls, google_api_key).select(|url, score| score)
   if scores.length > 0
     post_scores_to_mackerel(mackerel_service: mackerel_service, api_key: api_key, scores: scores)
   end

--- a/Rakefile
+++ b/Rakefile
@@ -119,7 +119,7 @@ task :post do
   google_api_key   = ENV['GOOGLE_APIKEY'] # optional
   urls             = ENV['URLS'].split(/\s/)
 
-  scores = fetch_psi_scores(urls, google_api_key)
+  scores = fetch_psi_scores(urls, google_api_key).select(|(url, score)| score)
   if scores.length > 0
     post_scores_to_mackerel(mackerel_service: mackerel_service, api_key: api_key, scores: scores)
   end


### PR DESCRIPTION
https://github.com/aereal/psi-metrics/pull/3 の作り直し版です．

- APIのバージョンアップにともないパラメータやレスポンスの形式を追従させた
- PSIがパーセント単位ではなく実数単位で値を返すようになったので100倍するようにした
- テストに便利なRakeタスクを追加した

の3点です．